### PR TITLE
changes to convo page and other little fixes

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -16,8 +16,10 @@ package codeu.controller;
 
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
+import codeu.model.data.Marker;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.MarkerStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -36,6 +38,9 @@ public class ConversationServlet extends HttpServlet {
   /** Store class that gives access to Conversations. */
   private ConversationStore conversationStore;
 
+  /** Store class that gives access to Markers. */
+  private MarkerStore markerStore;
+
   /**
    * Set up state for handling conversation-related requests. This method is only called when
    * running in a server, not when running in a test.
@@ -45,6 +50,7 @@ public class ConversationServlet extends HttpServlet {
     super.init();
     setUserStore(UserStore.getInstance());
     setConversationStore(ConversationStore.getInstance());
+    setMarkerStore(MarkerStore.getInstance());
   }
 
   /**
@@ -64,6 +70,14 @@ public class ConversationServlet extends HttpServlet {
   }
 
   /**
+   * Sets the MarkerStore used by this servlet. This function provides a common setup method
+   * for use by the test framework or the servlet's init() function.
+   */
+  void setMarkerStore(MarkerStore markerStore) {
+    this.markerStore = markerStore;
+  }
+
+  /**
    * This function fires when a user navigates to the conversations page. It gets all of the
    * conversations from the model and forwards to conversations.jsp for rendering the list.
    */
@@ -72,6 +86,8 @@ public class ConversationServlet extends HttpServlet {
       throws IOException, ServletException {
     List<Conversation> conversations = conversationStore.getAllConversations();
     request.setAttribute("conversations", conversations);
+    List<Marker> markers = markerStore.getAllMarkers();
+    request.setAttribute("markers", markers);
     request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
   }
 

--- a/src/main/webapp/WEB-INF/view/activity.jsp
+++ b/src/main/webapp/WEB-INF/view/activity.jsp
@@ -23,6 +23,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <title>Activity</title>
   <link rel="stylesheet" href="/css/main.css">
 </head>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -16,18 +16,24 @@
 <%@ page import="java.util.List" %>
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
+<%@ page import="codeu.model.data.Marker" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
 <%@ page import="codeu.model.store.basic.MessageStore" %>
+<%@ page import="codeu.model.store.basic.MarkerStore" %>
 <%
 Conversation conversation = (Conversation) request.getAttribute("conversation");
 List<Message> messages = (List<Message>) request.getAttribute("messages");
+Marker mkr = MarkerStore.getInstance().getMarkerByConvo(conversation.getId());
+String locName = mkr.getLocationName();
+double lat = mkr.getLatitude();
+double lng = mkr.getLongitude();
 %>
 
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
-  <title><%= conversation.getTitle() %></title>
+  <title><%= locName %></title>
   <link rel="stylesheet" href="/css/main.css" type="text/css">
 
   <style>
@@ -54,9 +60,9 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 
   <div id="container">
 
-    <h1><%= conversation.getTitle() %>
+    <h1><%= locName %>
       <a href="" style="float: right">&#8635;</a></h1>
-
+      Location: (Latitude: <%= lat %>, Longitude: <%= lng %>)
     <hr/>
 
     <div id="chat">

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -14,7 +14,7 @@
   limitations under the License.
 --%>
 <%@ page import="java.util.List" %>
-<%@ page import="codeu.model.data.Conversation" %>
+<%@ page import="codeu.model.data.Marker" %>
 
 <!DOCTYPE html>
 <html>
@@ -28,46 +28,30 @@
 
   <div id="container">
 
-    <% if(request.getAttribute("error") != null){ %>
-        <h2 style="color:red"><%= request.getAttribute("error") %></h2>
-    <% } %>
-
-    <% if(request.getSession().getAttribute("user") != null){ %>
-      <h1>New Conversation</h1>
-      <form action="/conversations" method="POST">
-          <div class="form-group">
-            <label class="form-control-label">Title:</label>
-          <input type="text" name="conversationTitle">
-        </div>
-
-        <button type="submit">Create</button>
-      </form>
-
-      <hr/>
-    <% } %>
-
     <h1>Conversations</h1>
 
     <%
-    List<Conversation> conversations =
-      (List<Conversation>) request.getAttribute("conversations");
-    if(conversations == null || conversations.isEmpty()){
+    List<Marker> markers =
+      (List<Marker>) request.getAttribute("markers");
+    if(markers == null || markers.isEmpty()){
     %>
-      <p>Create a conversation to get started.</p>
+      <p>Create a conversation to get started. Visit the <a href="/map">map</a> page to start a new conversation.</p>
     <%
     }
     else{
     %>
       <ul class="mdl-list">
     <%
-      for(Conversation conversation: conversations){
+      for(Marker marker: markers){
+      String convoName = marker.getLocationName().replaceAll("\\s", "");
     %>
-      <li><a href="/chat/<%= conversation.getTitle() %>">
-        <%= conversation.getTitle() %></a></li>
+      <li><a href="/chat/<%= convoName %>">
+        <%= marker.getLocationName() %></a></li>
     <%
       }
     %>
       </ul>
+      Log in and visit the <a href="/map">map</a> page to start a new conversation.
     <%
     }
     %>

--- a/src/main/webapp/WEB-INF/view/map.jsp
+++ b/src/main/webapp/WEB-INF/view/map.jsp
@@ -17,7 +17,7 @@
     <h1>The Map</h1>
     <ul>
     <li>To join a conversation that has already started at a location, just click on the marker that is there!</li>
-    <li>To add a new marker, log in and click on a spot on the map and then fill out the information below! <p>(Tip: click on the marker that you just created to see its exact coordinates)</p></li>
+    <li>To add a new marker, log in and click on a spot on the map. Be sure to fill out the location name field to succesfully save your marker and start a new conversation! <p>(Tip: click on the marker that you just created to see its exact coordinates)</p></li>
     </ul>
 
     <% if(request.getAttribute("error") != null){ %>
@@ -83,7 +83,7 @@
   // Adds a markerstore marker to the map.
       function addMarkerFromStore(location, map, markerName, convoName) {
         var contentString = '<h3 align="center">' + markerName +'</h3>' + '<a href="/chat/' + convoName 
-        +'">Click here</a> to join the conversation going on at this location!';
+        +'">Join</a> the conversation going on at this location!';
 
         var infowindow = new google.maps.InfoWindow({
           content: contentString

--- a/src/main/webapp/WEB-INF/view/map.jsp
+++ b/src/main/webapp/WEB-INF/view/map.jsp
@@ -46,15 +46,14 @@
       var markerLocs = [];
     <%
     List<Marker> markers = (List<Marker>) request.getAttribute("markers");
-    if(markers == null || markers.isEmpty()) {}
-    else {
-    for(Marker marker: markers) {
-    %>
-       markerLocs.push({lat: <%= marker.getLatitude() %>, lng: <%= marker.getLongitude() %>},);
-       locNames.push("<%= marker.getLocationName() %>",);
-       convoNames.push("<%= marker.getLocationName().replaceAll("\\s", "") %>",);
-  <%} 
-  }%>
+    if(markers != null && !markers.isEmpty()) {
+       for(Marker marker: markers) {
+       %>
+           markerLocs.push({lat: <%= marker.getLatitude() %>, lng: <%= marker.getLongitude() %>},);
+           locNames.push("<%= marker.getLocationName() %>",);
+          convoNames.push("<%= marker.getLocationName().replaceAll("\\s", "") %>",);
+       <%} 
+    }%>
 
   var map;
 
@@ -74,8 +73,7 @@
           document.querySelector("#longitudeVal").value = event.latLng.lng();
         });
 
-        if(markerLocs == null) {}
-        else {
+        if(markerLocs != null) {
           for (var i in markerLocs) {
             addMarkerFromStore(markerLocs[i], map, locNames[i], convoNames[i])
           }

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -31,16 +31,14 @@ DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.
   <meta charset="UTF-8">
   <title><%= user.getName() %>'s Profile Page</title>
   <link rel="stylesheet" href="/css/main.css">
-
-  <script>
+</head>
+<script>
     // scroll the chat div to the bottom
     function scrollActivity() {
       var activityDiv = document.getElementById('activity');
       activityDiv.scrollTop = activityDiv.scrollHeight;
     };
   </script>
-
-</head>
 <body onload="scrollActivity()">
 
   <%@ include file="/WEB-INF/view/navbar.jsp" %>
@@ -61,7 +59,7 @@ DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.
     <h2>Edit your About Me (Only you can see this)</h2>
 
     <form action="/profile/<%= user.getName() %>" method="POST">
-        <textarea id="text-box" name="info" cols="60" rows="5"><%= user.getAboutMe()%>
+        <textarea class="text-box" name="info" cols="60" rows="5"><%= user.getAboutMe()%>
         </textarea>
         <br/>
         <button type="submit">Submit</button>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -31,14 +31,14 @@ DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.
   <meta charset="UTF-8">
   <title><%= user.getName() %>'s Profile Page</title>
   <link rel="stylesheet" href="/css/main.css">
-</head>
-<script>
+  <script>
     // scroll the chat div to the bottom
     function scrollActivity() {
       var activityDiv = document.getElementById('activity');
       activityDiv.scrollTop = activityDiv.scrollHeight;
     };
   </script>
+</head>
 <body onload="scrollActivity()">
 
   <%@ include file="/WEB-INF/view/navbar.jsp" %>

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -27,7 +27,7 @@
     <div
       style="margin-left:auto; margin-right:auto; margin-top: 50px;">
 
-      <h1>About Team Ama's CodeU Chat App</h1>
+      <h1>About Team AMA's Chat App</h1>
       <p>
         Welcome to our chat application! Our chat app allows users to connect through conversations that are started at different locations on a google map. We wanted the map to be the focal point of our app so we turned it into a way for a user to join or start a conversation. Our chat app also has some other features that include:
       </p>
@@ -52,7 +52,7 @@
                 <a href="https://www.linkedin.com/in/aylinev/"><i class="fa fa-linkedin-square"></i></a>
 
                 </td>
-                <td><a href="http://aylinev2.github.io"><strong>Ayline Villegas</strong></a>
+                <td><a href="http://aylinev2.github.io"><strong>Ayline Villegas:</strong></a>
                 Currently studying Computer Science at The University of Illinois at Urbana Champaign. Hobbies include: taking pictures of my cats, baking, and playing a lot of sims!</td></tr>
 
 
@@ -64,14 +64,14 @@
                 <a href="https://www.linkedin.com/in/abeltran1804/"><i class="fa fa-linkedin-square"></i></a>
 
                 </td>
-                <td><strong>Anthony Beltran</strong>
+                <td><strong>Anthony Beltran:</strong>
                 Currently studying Computer Science at The University of Illinois at Chicago. Passions include: nature, AI, and food!
               </td></tr>
 
 
               <tr><td align="center"><img src="About-IMG/Default-Profile-IMG.png" class="prof-pic">
                 </td>
-                <td><strong>Marcel Gonzalez</strong>
+                <td><strong>Marcel Gonzalez:</strong>
                 Currently studying Computer Science at Tecnologico de Monterrey</td></tr>
 
             </table>

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -13,6 +13,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <title>CodeU Chat App</title>
   <link rel="stylesheet" href="/css/main.css">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
@@ -24,27 +25,16 @@
 
   <div id="container">
     <div
-      style="width:75%; margin-left:auto; margin-right:auto; margin-top: 50px;">
+      style="margin-left:auto; margin-right:auto; margin-top: 50px;">
 
-      <h1>About the CodeU Chat App</h1>
+      <h1>About Team Ama's CodeU Chat App</h1>
       <p>
-        This is an example chat application designed to be a starting point
-        for your CodeU project team work. Here's some stuff to think about:
+        Welcome to our chat application! Our chat app allows users to connect through conversations that are started at different locations on a google map. We wanted the map to be the focal point of our app so we turned it into a way for a user to join or start a conversation. Our chat app also has some other features that include:
       </p>
-
       <ul>
-        <li><strong>Algorithms and data structures:</strong> We've made the app
-            and the code as simple as possible. You will have to extend the
-            existing data structures to support your enhancements to the app,
-            and also make changes for performance and scalability as your app
-            increases in complexity.</li>
-        <li><strong>Look and feel:</strong> The focus of CodeU is on the Java
-          side of things, but if you're particularly interested you might use
-          HTML, CSS, and JavaScript to make the chat app prettier.</li>
-        <li><strong>Customization:</strong> Think about a group you care about.
-          What needs do they have? How could you help? Think about technical
-          requirements, privacy concerns, and accessibility and
-          internationalization.</li>
+        <li><strong>Activity Feed:</strong> A feed that shows all of the application's activity such as when users start conversations, write messages, or join the application.</li>
+        <li><strong>Profile Pages:</strong> Pages that display a user's about me and a mini feed that includes all of the messages a user has sent. When logged in, users have the option to edit their about me right from their profile page.</li>
+        <li><strong>Text Styling:</strong> The ability to style text by using certain BBCode tags ([b]wow![/b] -> <b>wow!</b>) or parse text to emojis (:cat: -> &#x1F431;). Our website also has a <a href="/guide.jsp">text styling guide</a> available for those who aren't familiar with BBCode tags and would like to learn how to use them on our site. </li>
       </ul>
 
       <p> <br>
@@ -52,16 +42,6 @@
         <ul>
           <div class="social-icons">
             <table cellpadding = "15" cellspacing = "1">
-              <tr><td align="center"><img src="About-IMG/Default-Profile-IMG.png" class="prof-pic">
-                <a href="https://github.com/MarcelRG"><i class="fa fa-github"></i></a>
-
-                <a href="ADD LINK HERE!!!!"><i class="fa fa-linkedin-square"></i></a>
-
-                </td>
-                <td><strong>Marcel Gonzalez</strong>
-                Currently studying Computer Science at Tecnologico de Monterrey</td></tr>
-              
-
               <tr><td align="center" ><img src="About-IMG/Ayline-Profile.gif" class="prof-pic">
                 <a href="https://www.facebook.com/ayline.villegas"><i class="fa fa-facebook-square"></i></a>
 
@@ -73,7 +53,7 @@
 
                 </td>
                 <td><a href="http://aylinev2.github.io"><strong>Ayline Villegas</strong></a>
-                Currently studying Computer Science at The University of Illinois at Urbana Champaign. Passions include: cats, baking, and music!</td></tr>
+                Currently studying Computer Science at The University of Illinois at Urbana Champaign. Hobbies include: taking pictures of my cats, baking, and playing a lot of sims!</td></tr>
 
 
               <tr><td align="center"><img src="About-IMG/Anthony-Profile-IMG.jpg" class="prof-pic">
@@ -87,6 +67,13 @@
                 <td><strong>Anthony Beltran</strong>
                 Currently studying Computer Science at The University of Illinois at Chicago. Passions include: nature, AI, and food!
               </td></tr>
+
+
+              <tr><td align="center"><img src="About-IMG/Default-Profile-IMG.png" class="prof-pic">
+                </td>
+                <td><strong>Marcel Gonzalez</strong>
+                Currently studying Computer Science at Tecnologico de Monterrey</td></tr>
+
             </table>
           </div>
         </ul>

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -15,16 +15,16 @@
 
 body {
   margin: 0;
-  font-family: sans-serif;
+  font-family: Geneva;
   line-height: 1.6;
   font-size: 18px;
   line-height: 1.6;
   color: #444;
-  background-color: #eeeeee;
+  background-color: #c7fffd;
 }
 
 nav {
-  background-color: #283593;
+  background-color: #353535;
 }
 
 nav a {

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -62,7 +62,7 @@ nav a {
   width: 550px;
 }
 
-#text-box {
+.text-box {
   padding:3%;
   font:18px sans-serif;
 }

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -27,7 +27,7 @@
     <div
       style="width:75%; margin-left:auto; margin-right:auto; margin-top: 50px;">
 
-      <h1>Team AMAa's CodeU Chat App</h1>
+      <h1>Team AMA's Chat App</h1>
       <h2>Welcome!</h2>
 
       <ul>
@@ -35,7 +35,7 @@
         <li>Go to the <a href="/map">map</a> page to
             find or create a new conversation at a certain location.</li>
         <li>View the <a href="/about.jsp">about</a> page to learn more about the
-            project and the team behind it!.</li>
+            project and the team behind it!</li>
       </ul>
     </div>
   </div>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -32,8 +32,8 @@
 
       <ul>
         <li><a href="/login">Login</a> to get started.</li>
-        <li>Go to the <a href="/conversations">conversations</a> page to
-            create or join a conversation.</li>
+        <li>Go to the <a href="/map">map</a> page to
+            find or create a new conversation at a certain location.</li>
         <li>View the <a href="/about.jsp">about</a> page to learn more about the
             project and the team behind it!.</li>
       </ul>

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -16,8 +16,10 @@ package codeu.controller;
 
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
+import codeu.model.data.Marker;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.MarkerStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -43,6 +45,7 @@ public class ConversationServletTest {
   private RequestDispatcher mockRequestDispatcher;
   private ConversationStore mockConversationStore;
   private UserStore mockUserStore;
+  private MarkerStore mockMarkerStore;
 
   @Before
   public void setup() {
@@ -62,6 +65,9 @@ public class ConversationServletTest {
 
     mockUserStore = Mockito.mock(UserStore.class);
     conversationServlet.setUserStore(mockUserStore);
+
+    mockMarkerStore = Mockito.mock(MarkerStore.class);
+    conversationServlet.setMarkerStore(mockMarkerStore);
   }
 
   @Test
@@ -71,9 +77,15 @@ public class ConversationServletTest {
         new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now()));
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
 
+    List<Marker> fakeMarkerList = new ArrayList<>();
+    fakeMarkerList.add(
+        new Marker(UUID.randomUUID(), UUID.randomUUID(), "test_loc_name", 47.8989, -10.323, Instant.now()));
+    Mockito.when(mockMarkerStore.getAllMarkers()).thenReturn(fakeMarkerList);
+
     conversationServlet.doGet(mockRequest, mockResponse);
 
     Mockito.verify(mockRequest).setAttribute("conversations", fakeConversationList);
+    Mockito.verify(mockRequest).setAttribute("markers", fakeMarkerList);
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 


### PR DESCRIPTION
changed convo page 
- removed ability to start convo from convo page
- displayed marker names instead of convo names bc convo names don't allow spaces etc. and it looks cleaner if marker names , that have spaces etc., are displayed

changed chat page
- displays marker name as title instead on convo name
- displays marker coordinates underneath title

- Made little fixes to typos and other text as well.

- activity page didn't display emoji correctly so I made a fix.

(sorry some of the things in this pull request don't relate I just wanted to get things done in time for deadline)